### PR TITLE
Fixes error on `undefined` in variadic args - improves CIDER patch

### DIFF
--- a/src/esprit/make_rom.clj
+++ b/src/esprit/make_rom.clj
@@ -3,8 +3,11 @@
    [clojure.java.io :as io]
    [clojure.string :as string]))
 
+(def argument-global "arguments2462148dcdc") ; Random so we don't get a name collision https://xkcd.com/221/
+
 (defn -main []
   (let [main-js    (-> (slurp "out/main.js")
+                       (string/replace "arguments" (str "[" argument-global "=arguments," argument-global "][1]"))
                        (string/replace "/[\\\\\"\\b\\f\\n\\r\\t]/g" "/[\\\\\"\\f\\n\\r\\t]/g")
                        (string/replace "goog.NONCE_PATTERN_=/^[\\w+/_-]+[=]{0,2}$/" "goog.NONCE_PATTERN_=null")
                        (string/replace "/^((https:)?\\/\\/[0-9a-z.:[\\]-]+\\/|\\/[^/\\\\]|[^:/\\\\%]+\\/|[^:/\\\\%]*[?#]|about:blank#)/i" "null")

--- a/src/esprit/repl.cljs
+++ b/src/esprit/repl.cljs
@@ -14,25 +14,20 @@
 (defn- write [c o]
   (ind/indicate-eval false)
   (doto c
-    (.write (.stringify js/JSON o))
-    (.write "\0"))
+     (.write (.stringify js/JSON o))
+     (.write "\0"))
   (ind/indicate-print))
 
-(defn fn-ify
-  "Wraps bare try-catch into a fn as to properly return pr_str"
-  [js]
-  (str "(function(){try{return " (subs js 4 (dec (count js))) "})()"))
-
 (defn eval-data [data]
-  (let [response (try
-                   (ind/indicate-eval true)
-                   #js {:status "success"
-                        :value  (js/eval data)}
-                   (catch :default ex
-                     #js {:status     "exception"
-                          :value      (str ex)
-                          :stacktrace (.-stack ex)}))]
-    (write c response)))
+  (println data)
+  (try
+    (ind/indicate-eval true)
+    #js {:status "success"
+         :value  (js/eval data)}
+    (catch :default ex
+      #js {:status "exception"
+           :value (str ex)
+           :stacktrace (.-stack ex)})))
 
 (defn- handle-repl-connection [c]
   (.log js/console "New REPL Connection")
@@ -51,10 +46,7 @@
                (reset! buffer "")
                (cond
                  (string/starts-with? data "(function (){try{return cljs.core.pr_str")
-                 (eval-data data)
-
-                 (string/starts-with? data "try{cljs.core.pr_str.call")
-                 (eval-data data)
+                 (write c (eval-data data))
 
                  (= data ":cljs/quit")
                  (.end c)


### PR DESCRIPTION
This is an Espruino bug: https://github.com/espruino/Espruino/issues/1691

This fix patches every instance of `arguments` with `[x=arguments,x][1]` where `x` is some hopefully non-conflicting random name.

Unfortunately, this increases the binary size quite a bit, by about 100K. But, now that we have 3MB, it should be OK.

Additionally, I moved the CIDER fix to the client-side repl code to avoid doing big string operations on device, this gave a major performance boost. 